### PR TITLE
grunt-ejs-static is almost exactly what I needed, but here's some improvements I wanted to make.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ This sets the index page for the site (example/dev/pages/home/index.html)
 #### options.data
 Type: `String`
 
-The json data to populate EJS templates
+The json data to populate EJS templates. The parent directory of a layout manager is used as the key into the JSON file and is case-sensitive.
+
+The JSON element with the empty string as its name is injected into all the other objects as the `global` property.
 
 ### Files
 
@@ -115,4 +117,6 @@ This builds static html into example/production/
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
-_(Nothing yet)_
+### 0.2.0 
+* Added a way to get site-wide variables into the models for individual layouts.
+* Added logging of debugging information to show what is happening in the task.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This sets the index page for the site (example/dev/pages/home/index.html)
 #### options.data
 Type: `String`
 
-The json data to populate EJS templates. The parent directory of a layout manager is used as the key into the JSON file and is case-sensitive.
+The json data to populate EJS templates. The parent directory of a layout manager is used as the key into the JSON file and is case-sensitive. There must be an entry in the json data for each layout manager.
 
 The JSON element with the empty string as its name is injected into all the other objects as the `global` property.
 

--- a/example/dev/data/pages.json
+++ b/example/dev/data/pages.json
@@ -1,9 +1,13 @@
 {
-
+  "": {
+    "site_name": "Grunt-EJS-Static Example",
+	"analytics_id": "UA-XXXXXX"
+  },
+  
   "home": {
     "page_name": "home",
     "page_category": "page",
-    "title": "Grunt-EJS-Static | Home",
+    "title": "Home",
     "description": "Compile static html from ejs templates",
     "keywords":  "gruntplugin, ejs, static html, static site generator, templates, templating engine, template, embedded js"
   },
@@ -11,7 +15,7 @@
   "about": {
     "page_name": "about",
     "page_category": "page",
-    "title": "Grunt-EJS-Static | About",
+    "title": "About",
     "description": "Compile static html from ejs templates",
     "keywords":  "gruntplugin, ejs, static html, static site generator, templates, templating engine, template, embedded js"
   }

--- a/example/dev/templates/global/head.ejs
+++ b/example/dev/templates/global/head.ejs
@@ -9,7 +9,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-    <title><%= title %></title>
+    <title><%= global.site_name + " | " + title %></title>
     <meta name="description" content="<%= description %>">
     <meta name="keywords" content="<%= keywords %>" >
 
@@ -27,7 +27,7 @@
 
     <!-- google analytics -->
     <script>
-      var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+      var _gaq=[['_setAccount','<%= global.analytics_id%>'],['_trackPageview']];
       (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
       g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
       s.parentNode.insertBefore(g,s)}(document,'script'));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-ejs-static",
   "description": "Compile static html from ejs templates",
-  "version": "0.1.81",
+  "version": "0.2.0",
   "homepage": "https://github.com/shaekuronen/grunt-ejs-static",
   "author": {
     "name": "Shae Kuronen",

--- a/tasks/ejs_static.js
+++ b/tasks/ejs_static.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
 		if (global_data) {
 			this_data.global = global_data;
 			grunt.log.debug('Added global data to model object');
-		};
+		}
 
         // set the base dir for includes
         // tj uses filename to set base dir for includes in ejs.js

--- a/tasks/ejs_static.js
+++ b/tasks/ejs_static.js
@@ -64,6 +64,13 @@ module.exports = function(grunt) {
 			grunt.log.error('Could not find model for ' + the_parent_directory + ' in data json');
 		}
 
+		// Pull in any site-wide variables like the name of the site or Google Analytics id.
+		var global_data = the_data[''];
+		if (global_data) {
+			this_data.global = global_data;
+			grunt.log.debug('Added global data to model object');
+		};
+
         // set the base dir for includes
         // tj uses filename to set base dir for includes in ejs.js
         // which make the include relative to the file

--- a/tasks/ejs_static.js
+++ b/tasks/ejs_static.js
@@ -41,38 +41,47 @@ module.exports = function(grunt) {
       })
       .forEach(function(filepath) {
 
+		grunt.log.debug('Processing layout manager at filepath ' + filepath);
+
         // get the parent directory of layout manager
         var the_parent_directory = get_parent_directory(filepath);
+		grunt.log.debug('Looking in parent directory ' + the_parent_directory);
 
         // get the path to the parent directory
         var the_path_to_rendered_template = get_path_to_rendered_template(filepath, options.layout_src, file.dest);
+		grunt.log.debug('Using path ' + the_path_to_rendered_template + ' to read layout manager file.');
 
         // get the template
         var the_template = grunt.file.read(filepath);
+		grunt.log.debug('Read template from ' + filepath);
 
         // get the data using bracket notation so it's possible for the identifier to start with a number
         var this_data = the_data[the_parent_directory];
+		if (this_data) {
+			grunt.log.debug('Retrieved model object from data json');
+		}
+		else {
+			grunt.log.error('Could not find model for ' + the_parent_directory + ' in data json');
+		}
 
         // set the base dir for includes
         // tj uses filename to set base dir for includes in ejs.js
         // which make the include relative to the file
         // see resolveInclude() in visionmedia/ejs/lib/ejs.js
-        this_data.filename = filepath;    
+        this_data.filename = filepath;
 
         // render the template as html
         var the_rendered_template = ejs.render(the_template, this_data);
 
         // check to see if the current file is specified as the root index.html page
         if (filepath === options.index_page) {
-
-          // write the compiled template to the document root
-          grunt.file.write(file.dest + 'index.html', the_rendered_template);
-
+            // write the compiled template to the document root
+            grunt.file.write(file.dest + 'index.html', the_rendered_template);
+			grunt.log.debug('Wrote site index file to ' + file.dest + 'index.html');
         } else {
-
-          // write the compiled template to the destination directory
-          grunt.file.write(the_path_to_rendered_template, the_rendered_template);
-
+			// write the compiled template to the destination directory
+			grunt.file.write(the_path_to_rendered_template, the_rendered_template);
+			grunt.log.debug('Wrote result to ' + the_path_to_rendered_template);
         }
 
       });


### PR DESCRIPTION
What got me started was a random error that grunt threw up - "Could not set filename property of undefined". I added the debugging logs so that I knew what was going on and why and an error message to make sure that nobody else gets confused while learning.

The other improvement is using the empty string as a place to store variables like the Google Analytics ID which only need to be set once for an entire site.

I bumped the version number to 0.2 because of the extra global variables feature. That's correct under my understanding of Semantic Versioning but I'd like to know if you think that was right.
